### PR TITLE
When listing packages, encode the output as UTF-8 before printing

### DIFF
--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -541,7 +541,7 @@ def do_list(args):
         if args.name_only:
             out = "   " + pkg['name']
 
-        print out
+        print out.encode('utf-8')
         cnt = cnt + 1
     if not args.name_only:
         print 'Total: {0} packages'.format(cnt)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/1163070
