### PR TITLE
Report an error if the fedora-review flag is not set to `+`

### DIFF
--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -204,6 +204,10 @@ def check_package_creation(info, bugid, pkgdbclient):
                 messages.append(
                     ' ! User {0} is not a packager but set the '
                     'fedora-review flag to `+`'.format(flag['setter']))
+        elif flag['name'] == 'fedora-review' and flag['status'] != '+':
+            messages.append(
+                ' ! fedora-review flag is no `+` but is still `%s`' %
+                flag['status'])
 
     msgs2 = check_branch_creation(
         pkgdbclient,


### PR DESCRIPTION
The fedora-review flag must be set as `+` for a new package to be added
to pkgdb. So far we were checking who set the flag to `+` but not *if*
it has been set to this status.

This commit fixes this situation