### PR TITLE
Set default BeautifulSoup parser

### DIFF
--- a/pkgdb2client/__init__.py
+++ b/pkgdb2client/__init__.py
@@ -70,7 +70,7 @@ def _parse_service_form(response):
     """
     import bs4
 
-    parsed = bs4.BeautifulSoup(response.text)
+    parsed = bs4.BeautifulSoup(response.text, "lxml")
     inputs = {}
     for child in parsed.form.find_all(name='input'):
         if child.attrs['type'] == 'submit':


### PR DESCRIPTION
This is required to get rid of a UserWarning in Fedora 22.

This is the warning I get:
```
/usr/lib/python2.7/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if y
ou run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "lxml")

```