### PR TITLE
Define version variable before use

### DIFF
--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -793,6 +793,7 @@ def do_monitoring(args):
     LOG.info("package     : {0}".format(args.package))
     LOG.info("monitoring  : {0}".format(args.monitoring))
 
+    version = pkgdbclient.get_version()
     if version < (1, 13):
         raise PkgDBException(
             'This version of PkgDB does not support monitoring')
@@ -818,6 +819,7 @@ def do_koschei(args):
     LOG.info("package  : {0}".format(args.package))
     LOG.info("koschei  : {0}".format(args.koschei))
 
+    version = pkgdbclient.get_version()
     if version < (1, 16):
         raise PkgDBException(
             'This version of PkgDB does not support koschei monitoring')


### PR DESCRIPTION
This fixes the following traceback:

```
Traceback (most recent call last):
  File "pkgdb2client/cli.py", line 890, in main
    arg.func(arg)
  File "pkgdb2client/cli.py", line 821, in do_koschei
    if version < (1, 16):
NameError: global name 'version' is not defined
```