### PR TITLE
Fix set_koschei_status() argument name

### DIFF
--- a/pkgdb2client/__init__.py
+++ b/pkgdb2client/__init__.py
@@ -1118,9 +1118,9 @@ class PkgDB(object):
 
         :arg pkgname: The name of the package
         :type pkgname: str
-        :arg monitoring: The koschei status to set the package to. Can
+        :arg koschei The koschei status to set the package to. Can
             be any of: True, 1, False, 0.
-        :type monitoring: str
+        :type koschei str
 
         '''
         valid = ['true', '1', 'false', '0']
@@ -1131,7 +1131,7 @@ class PkgDB(object):
             )
         args = {
             'package': pkgname,
-            'status': monitoring,
+            'status': koschei,
         }
         return self.handle_api_call(
-            '/package/%s/koschei/%s' % (pkgname, monitoring), data=args)
+            '/package/%s/koschei/%s' % (pkgname, koschei), data=args)


### PR DESCRIPTION
Fixes the following traceback:

```
Traceback (most recent call last):
  File "pkgdb2client/cli.py", line 892, in main
    arg.func(arg)
  File "pkgdb2client/cli.py", line 834, in do_koschei
    output = pkgdbclient.set_koschei_status(args.package, args.koschei)
  File "/home/kojan/tmp/packagedb-cli/pkgdb2client/__init__.py", line 1134, in set_koschei_status
    'status': monitoring,
NameError: global name 'monitoring' is not defined
```