### PR TITLE
Unretirerequests

### DIFF
--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -335,7 +335,7 @@ def __handle_request_package(actionid, action):
         comaintainers = action['info'].get('co-maintainers')
         if comaintainers:
             for user in comaintainers.split(','):
-                output = PKGDBCLIENT.update_acl(
+                PKGDBCLIENT.update_acl(
                     action['info']['pkg_name'],
                     branches=action['info']['pkg_collection'],
                     acls=['commit', 'watchbugzilla', 'watchcommits'],

--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -524,7 +524,8 @@ def do_process(args):
         elif action['action'] == 'request.unretire':
             data = __handle_request_unretire(actionid, action)
         else:
-            print('Action %s not supported by pkgdb-cli' % action['action'])
+            print('Action {0} not supported by pkgdb-admin'.format(
+                action['action']))
             continue
 
         for msg in data.get('messages', []):

--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -346,9 +346,11 @@ def __handle_request_package(actionid, action):
 
         approve_action(actionid)
 
-        ns = '%s/' % action['info'].get('pkg_namespace', 'rpms')
+        url = "{0}/package/{1}/{2}".format(
+            PKGDBCLIENT.base_url,
+            action['info'].get('pkg_namespace', 'rpms'),
+            action['info']['pkg_name'])
 
-        url = PKGDBCLIENT.base_url + '/package/' + ns + action['info']['pkg_name']
         utils.comment_on_bug(
             bugid,
             'Package request has been approved: %s' % url


### PR DESCRIPTION
This adds initial unretire support. It is currently mainly useful to do the checks needed for unretirement and it shows hints about what to do next. Eventually it should actually do the unretirement itself, but this needs some for checks for figure out what needs to be done, e.g. which koji tag to unblock it.