### PR TITLE
Fix setting the co-maintainers when auto-approving new branches

### DIFF
--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -422,6 +422,18 @@ def __handle_request_branch(actionid, action, package):
             namespace=action['package'].get('namespace', 'rpms'),
         )
 
+        comaintainers = action.get('info', {}).get('co-maintainers')
+        if comaintainers:
+            for user in comaintainers.split(','):
+                PKGDBCLIENT.update_acl(
+                    action['info']['pkg_name'],
+                    branches=action['info']['pkg_collection'],
+                    acls=['commit', 'watchbugzilla', 'watchcommits'],
+                    status='Approved',
+                    user=user.strip(),
+                    namespace=action['info']['pkg_namespace'],
+                )
+
         approve_action(actionid)
 
     elif decision in ('deny', 'd'):


### PR DESCRIPTION
This code path is hit when a package is requested to be created in
multiple Fedora branches. The package gets created in the first request
(most likely master) then the other branches are processed, but since the
package is in pkgdb, the action is re-qualified into request.branch and
that doesn't/didn't include adding the co-maintainers.

Fixes https://github.com/fedora-infra/pkgdb2/issues/385