### PR TITLE
Change description of 'acl' action.

### DIFF
--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -224,7 +224,7 @@ def setup_parser():
     # ACL
     parser_acl = subparsers.add_parser(
         'acl',
-        help='Request acl for a given package')
+        help='Display ACLs for a given package')
     parser_acl.add_argument('package', help="Name of the package to query")
     parser_acl.add_argument(
         'branch', default='master', nargs="?",


### PR DESCRIPTION
Both the 'acl' and 'request' actions indicate that they "Request" ACLs
on a package, but in reality the 'acl' action simply displays them.
Change the description to indicate that the 'acl' action actually
displays the ACLs