### PR TITLE
More info on failure, please.

### DIFF
--- a/pkgdb2client/__init__.py
+++ b/pkgdb2client/__init__.py
@@ -212,8 +212,11 @@ class PkgDB(OpenIdBaseClient):
         if not output or 'error' in output:
             LOG.debug('full output: {0}'.format(output))
             if output and 'error' in output:
-                raise PkgDBException("%s: %r" % (
-                    output['error'], output.get('error_detail')))
+                if 'error_detail' in output:
+                    raise PkgDBException("%s: %r" % (
+                        output['error'], output['error_detail']))
+                else:
+                    raise PkgDBException(output['error'])
             elif output is None:
                 raise PkgDBException('No output returned by %s' % path)
             else:

--- a/pkgdb2client/__init__.py
+++ b/pkgdb2client/__init__.py
@@ -212,7 +212,8 @@ class PkgDB(OpenIdBaseClient):
         if not output or 'error' in output:
             LOG.debug('full output: {0}'.format(output))
             if output and 'error' in output:
-                raise PkgDBException(output['error'])
+                raise PkgDBException("%s: %r" % (
+                    output['error'], output.get('error_detail')))
             elif output is None:
                 raise PkgDBException('No output returned by %s' % path)
             else:


### PR DESCRIPTION
Often, the failure is because "Invalid input submitted" is in the
`error` field.. but it doesn't tell you what about your input is
invalid.  It is... difficult to get at the `error_detail`.

This change should make it more obvious to users why their request failed.