### PR TITLE
[RFC] Use default parser

### DIFF
--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -64,7 +64,7 @@ def setup_parser():
                         help="Base url of the pkgdb instance to query.")
     parser.add_argument('--fasurl',
                         help="Base url of the FAS instance to query.")
-    parser.add_argument('--bzurl',
+    parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")
 
     subparsers = parser.add_subparsers(title='actions')

--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -62,7 +62,7 @@ def setup_parser():
                         "certificates")
     parser.add_argument('--pkgdburl',
                         help="Base url of the pkgdb instance to query.")
-    parser.add_argument('--fasurl',
+    parser.add_argument('--fasurl', default='https://admin.fedoraproject.org/accounts',
                         help="Base url of the FAS instance to query.")
     parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -212,7 +212,7 @@ def setup_parser():
                         "certificates")
     parser.add_argument('--pkgdburl',
                         help="Base url of the pkgdb instance to query.")
-    parser.add_argument('--fasurl',
+    parser.add_argument('--fasurl', default='https://admin.fedoraproject.org/accounts',
                         help="Base url of the FAS instance to query.")
     parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -28,8 +28,6 @@ import pkgdb2client
 import pkgdb2client.utils
 
 
-KOJI_HUB = 'http://koji.fedoraproject.org/kojihub'
-
 pkgdbclient = PkgDB('https://admin.fedoraproject.org/pkgdb',
                     login_callback=pkgdb2client.ask_password)
 BOLD = "\033[1m"
@@ -130,7 +128,7 @@ def _get_last_build(packagename, tag):
 
     '''
     LOG.debug("Search last build for {0} in {1}".format(packagename, tag))
-    kojiclient = koji.ClientSession(KOJI_HUB, {})
+    kojiclient = koji.ClientSession(arg.kojihuburl, {})
 
     data = kojiclient.getLatestBuilds(
         tag, package=packagename)
@@ -218,6 +216,8 @@ def setup_parser():
                         help="Base url of the FAS instance to query.")
     parser.add_argument('--bzurl',
                         help="Base url of the bugzilla instance to query.")
+    parser.add_argument('--kojihuburl', default='http://koji.fedoraproject.org/kojihub' ,
+                        help="Base url of the koji-hub instance to query.")
 
     subparsers = parser.add_subparsers(title='actions')
 

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -214,7 +214,7 @@ def setup_parser():
                         help="Base url of the pkgdb instance to query.")
     parser.add_argument('--fasurl',
                         help="Base url of the FAS instance to query.")
-    parser.add_argument('--bzurl',
+    parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")
     parser.add_argument('--kojihuburl', default='http://koji.fedoraproject.org/kojihub' ,
                         help="Base url of the koji-hub instance to query.")

--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -37,14 +37,13 @@ except fedora_cert.fedora_cert_error:
     pkgdb2client.LOG.debug('Could not read Fedora cert, asking for username')
     USERNAME = None
 
-RH_BZ_API = 'https://bugzilla.redhat.com/xmlrpc.cgi'
 BZCLIENT = None
 FASCLIENT = AccountSystem(
     'https://admin.fedoraproject.org/accounts',
     username=USERNAME)
 
 
-def _get_bz(url=RH_BZ_API, insecure=False):
+def _get_bz(url=arg.bzurl, insecure=False):
     ''' Return a bugzilla object. '''
     global BZCLIENT
     if not BZCLIENT:

--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -39,7 +39,7 @@ except fedora_cert.fedora_cert_error:
 
 BZCLIENT = None
 FASCLIENT = AccountSystem(
-    'https://admin.fedoraproject.org/accounts',
+    arg.fasurl,
     username=USERNAME)
 
 


### PR DESCRIPTION
Using the default value in parser allows to override the URL earlier in the code.
Once done it will be easier to operate on the correct URL from the start and avoid to fixup URL later.

This is tagged as RFC since this breaks condition like this (when we want to display alternatives URL):
`    if arg.bzurl:
`
I would suggest to fix using that instead:
`    if arg.bzurl  != BZURL_DEFAULT:`
Having a BZURL_DEFAULT in cli.py and admin.py

Then another issue is about code duplication between theses two files.
