### PR TITLE
Use the default argument in the command line arguments parser

### DIFF
--- a/pkgdb2client/__init__.py
+++ b/pkgdb2client/__init__.py
@@ -41,6 +41,9 @@ LOG.addHandler(hand)
 
 __version__ = pkg_resources.get_distribution('packagedb-cli').version
 PKGDB_URL = r'https://admin.fedoraproject.org/pkgdb/'
+FAS_URL = r'https://admin.fedoraproject.org/accounts'
+BZ_URL = r'https://bugzilla.redhat.com/xmlrpc.cgi'
+KOJI_HUB = r'http://koji.fedoraproject.org/kojihub'
 
 
 class PkgDBException(Exception):

--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -65,7 +65,7 @@ def setup_parser():
                         help="Base url of the pkgdb instance to query.")
     parser.add_argument('--fasurl',
                         help="Base url of the FAS instance to query.")
-    parser.add_argument('--bzurl',
+    parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")
 
     subparsers = parser.add_subparsers(title='actions')

--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -29,8 +29,9 @@ import pkgdb2client
 import pkgdb2client.utils as utils
 
 
-PKGDBCLIENT = PkgDB('https://admin.fedoraproject.org/pkgdb',
-                    login_callback=pkgdb2client.ask_password)
+PKGDBCLIENT = PkgDB(
+    pkgdb2client.PKGDB_URL, login_callback=pkgdb2client.ask_password)
+
 BOLD = "\033[1m"
 RED = "\033[0;31m"
 RESET = "\033[0;0m"
@@ -61,11 +62,11 @@ def setup_parser():
     parser.add_argument('--insecure', action='store_true', default=False,
                         help="Tells pkgdb-cli to ignore invalid SSL "
                         "certificates")
-    parser.add_argument('--pkgdburl',
+    parser.add_argument('--pkgdburl', default=pkgdb2client.PKGDB_URL,
                         help="Base url of the pkgdb instance to query.")
-    parser.add_argument('--fasurl', default='https://admin.fedoraproject.org/accounts',
+    parser.add_argument('--fasurl', default=pkgdb2client.FAS_URL,
                         help="Base url of the FAS instance to query.")
-    parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
+    parser.add_argument('--bzurl', default=pkgdb2client.BZ_URL,
                         help="Base url of the bugzilla instance to query.")
 
     subparsers = parser.add_subparsers(title='actions')
@@ -594,7 +595,7 @@ def main():
         LOG.setLevel(logging.INFO)
 
     global PKGDBCLIENT
-    if arg.pkgdburl:
+    if arg.pkgdburl != pkgdb2client.PKGDB_URL:
         LOG.info("Querying pkgdb at: %s", arg.pkgdburl)
         PKGDBCLIENT = PkgDB(
             arg.pkgdburl,
@@ -602,16 +603,15 @@ def main():
 
     PKGDBCLIENT.insecure = arg.insecure
 
-    if arg.bzurl:
+    if arg.bzurl != pkgdb2client.BZ_URL:
         if not arg.bzurl.endswith('xmlrpc.cgi'):
             arg.bzurl = '%s/xmlrpc.cgi' % arg.bzurl
         LOG.info("Querying bugzilla at: %s", arg.bzurl)
         utils._get_bz(arg.bzurl, insecure=arg.insecure)
 
-    if arg.fasurl:
+    if arg.fasurl != pkgdb2client.FAS_URL:
         LOG.info("Querying FAS at: %s", arg.fasurl)
-        utils.FASCLIENT.base_url = arg.fasurl
-        utils.FASCLIENT.insecure = arg.insecure
+        utils._get_bz(arg.fasurl, insecure=arg.insecure)
 
     return_code = 0
 

--- a/pkgdb2client/admin.py
+++ b/pkgdb2client/admin.py
@@ -63,7 +63,7 @@ def setup_parser():
                         "certificates")
     parser.add_argument('--pkgdburl',
                         help="Base url of the pkgdb instance to query.")
-    parser.add_argument('--fasurl',
+    parser.add_argument('--fasurl', default='https://admin.fedoraproject.org/accounts',
                         help="Base url of the FAS instance to query.")
     parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -212,7 +212,7 @@ def setup_parser():
                         "certificates")
     parser.add_argument('--pkgdburl',
                         help="Base url of the pkgdb instance to query.")
-    parser.add_argument('--fasurl',
+    parser.add_argument('--fasurl', default='https://admin.fedoraproject.org/accounts',
                         help="Base url of the FAS instance to query.")
     parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -28,8 +28,6 @@ import pkgdb2client
 import pkgdb2client.utils
 
 
-KOJI_HUB = 'http://koji.fedoraproject.org/kojihub'
-
 pkgdbclient = PkgDB('https://admin.fedoraproject.org/pkgdb',
                     login_callback=pkgdb2client.ask_password)
 BOLD = "\033[1m"
@@ -130,7 +128,7 @@ def _get_last_build(packagename, tag):
 
     '''
     LOG.debug("Search last build for {0} in {1}".format(packagename, tag))
-    kojiclient = koji.ClientSession(KOJI_HUB, {})
+    kojiclient = koji.ClientSession(arg.kojihuburl, {})
 
     data = kojiclient.getLatestBuilds(
         tag, package=packagename)
@@ -218,6 +216,8 @@ def setup_parser():
                         help="Base url of the FAS instance to query.")
     parser.add_argument('--bzurl',
                         help="Base url of the bugzilla instance to query.")
+    parser.add_argument('--kojihuburl', default='http://koji.fedoraproject.org/kojihub' ,
+                        help="Base url of the koji-hub instance to query.")
 
     subparsers = parser.add_subparsers(title='actions')
 

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -214,7 +214,7 @@ def setup_parser():
                         help="Base url of the pkgdb instance to query.")
     parser.add_argument('--fasurl',
                         help="Base url of the FAS instance to query.")
-    parser.add_argument('--bzurl',
+    parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
                         help="Base url of the bugzilla instance to query.")
     parser.add_argument('--kojihuburl', default='http://koji.fedoraproject.org/kojihub' ,
                         help="Base url of the koji-hub instance to query.")

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -992,7 +992,7 @@ def main():
 
     if arg.fasurl != pkgdb2client.FAS_URL:
         print("Querying FAS at: %s" % arg.fasurl)
-        utils._get_bz(arg.fasurl, insecure=arg.insecure)
+        utils._get_fas(arg.fasurl, insecure=arg.insecure)
 
     if arg.kojihuburl != pkgdb2client.KOJI_HUB:
         print("Querying koji at: %s" % arg.kojihuburl)

--- a/pkgdb2client/cli.py
+++ b/pkgdb2client/cli.py
@@ -28,8 +28,9 @@ import pkgdb2client
 import pkgdb2client.utils
 
 
-pkgdbclient = PkgDB('https://admin.fedoraproject.org/pkgdb',
-                    login_callback=pkgdb2client.ask_password)
+pkgdbclient = PkgDB(
+    pkgdb2client.PKGDB_URL, login_callback=pkgdb2client.ask_password)
+
 BOLD = "\033[1m"
 RED = "\033[0;31m"
 RESET = "\033[0;0m"
@@ -210,13 +211,13 @@ def setup_parser():
     parser.add_argument('--insecure', action='store_true', default=False,
                         help="Tells pkgdb-cli to ignore invalid SSL "
                         "certificates")
-    parser.add_argument('--pkgdburl',
+    parser.add_argument('--pkgdburl', default=pkgdb2client.PKGDB_URL,
                         help="Base url of the pkgdb instance to query.")
-    parser.add_argument('--fasurl', default='https://admin.fedoraproject.org/accounts',
+    parser.add_argument('--fasurl', default=pkgdb2client.FAS_URL,
                         help="Base url of the FAS instance to query.")
-    parser.add_argument('--bzurl', default='https://bugzilla.redhat.com/xmlrpc.cgi',
+    parser.add_argument('--bzurl', default=pkgdb2client.BZ_URL,
                         help="Base url of the bugzilla instance to query.")
-    parser.add_argument('--kojihuburl', default='http://koji.fedoraproject.org/kojihub' ,
+    parser.add_argument('--kojihuburl', default=pkgdb2client.KOJI_HUB,
                         help="Base url of the koji-hub instance to query.")
 
     subparsers = parser.add_subparsers(title='actions')
@@ -975,7 +976,7 @@ def main():
         LOG.setLevel(logging.INFO)
 
     global pkgdbclient
-    if arg.pkgdburl:
+    if arg.pkgdburl != pkgdb2client.PKGDB_URL:
         print("Querying pkgdb at: %s" % arg.pkgdburl)
         pkgdbclient = PkgDB(
             arg.pkgdburl,
@@ -983,17 +984,20 @@ def main():
 
     pkgdbclient.insecure = arg.insecure
 
-    if arg.bzurl:
+    if arg.bzurl != pkgdb2client.BZ_URL:
         if not arg.bzurl.endswith('xmlrpc.cgi'):
             arg.bzurl = '%s/xmlrpc.cgi' % arg.bzurl
         print("Querying bugzilla at: %s" % arg.bzurl)
-        pkgdb2client.utils.BZCLIENT.url = arg.bzurl
-        pkgdb2client.utils.BZCLIENT._sslverify = not arg.insecure
+        utils._get_bz(arg.bzurl, insecure=arg.insecure)
 
-    if arg.fasurl:
+    if arg.fasurl != pkgdb2client.FAS_URL:
         print("Querying FAS at: %s" % arg.fasurl)
-        pkgdb2client.utils.FASCLIENT.base_url = arg.fasurl
-        pkgdb2client.utils.FASCLIENT.insecure = arg.insecure
+        utils._get_bz(arg.fasurl, insecure=arg.insecure)
+
+    if arg.kojihuburl != pkgdb2client.KOJI_HUB:
+        print("Querying koji at: %s" % arg.kojihuburl)
+        global KOJI_HUB
+        KOJI_HUB = arg.kojihuburl
 
     return_code = 0
 

--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -37,14 +37,13 @@ except fedora_cert.fedora_cert_error:
     pkgdb2client.LOG.debug('Could not read Fedora cert, asking for username')
     USERNAME = None
 
-RH_BZ_API = 'https://bugzilla.redhat.com/xmlrpc.cgi'
 BZCLIENT = None
 FASCLIENT = AccountSystem(
     'https://admin.fedoraproject.org/accounts',
     username=USERNAME)
 
 
-def _get_bz(url=RH_BZ_API, insecure=False):
+def _get_bz(url=arg.bzurl, insecure=False):
     ''' Return a bugzilla object. '''
     global BZCLIENT
     if not BZCLIENT:

--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -39,7 +39,7 @@ except fedora_cert.fedora_cert_error:
 
 BZCLIENT = None
 FASCLIENT = AccountSystem(
-    'https://admin.fedoraproject.org/accounts',
+    arg.fasurl,
     username=USERNAME)
 
 

--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -38,6 +38,7 @@ except fedora_cert.fedora_cert_error:
     USERNAME = None
 
 BZCLIENT = None
+FASCLIENT = None
 
 
 def _get_bz(url=pkgdb2client.BZ_URL, insecure=False):

--- a/pkgdb2client/utils.py
+++ b/pkgdb2client/utils.py
@@ -38,18 +38,13 @@ except fedora_cert.fedora_cert_error:
     USERNAME = None
 
 BZCLIENT = None
-FASCLIENT = AccountSystem(
-    arg.fasurl,
-    username=USERNAME)
 
 
-def _get_bz(url=arg.bzurl, insecure=False):
+def _get_bz(url=pkgdb2client.BZ_URL, insecure=False):
     ''' Return a bugzilla object. '''
     global BZCLIENT
-    if not BZCLIENT:
+    if not BZCLIENT or BZCLIENT.url != url:
         BZCLIENT = Bugzilla(url=url)
-    elif BZCLIENT.url != url:
-        BZCLIENT.url = url
 
     BZCLIENT._sslverify = not insecure
 
@@ -59,6 +54,18 @@ def _get_bz(url=arg.bzurl, insecure=False):
         bz_login()
 
     return BZCLIENT
+
+
+def _get_fas(url=pkgdb2client.FAS_URL, insecure=False):
+    ''' Return a bugzilla object. '''
+    global FASCLIENT
+    if not FASCLIENT or FASCLIENT.base_url != url:
+        FASCLIENT = AccountSystem(
+            url, username=USERNAME)
+
+    FASCLIENT.insecure = insecure
+
+    return FASCLIENT
 
 
 def bz_login():
@@ -158,6 +165,8 @@ def __get_fas_user_by_email(email_address):
     :arg email_address: the email address of the user to retrieve in FAS.
 
     '''
+    FASCLIENT = _get_fas()
+
     if email_address in FASCLIENT._AccountSystem__alternate_email:
         userid = FASCLIENT._AccountSystem__alternate_email[email_address]
 
@@ -226,6 +235,8 @@ def is_packager(user):
     :arg email_address: the email address of the user to retrieve in FAS.
 
     '''
+    FASCLIENT = _get_fas()
+
     if '@' in user:
         fas_user = __get_fas_user_by_email(user.strip())
     else:


### PR DESCRIPTION
- Centralize in one location all the URL hard-coded
- Use these URLs in the CLI argument parser
- Adjust how the bugzilla and FAS clients are instantiated.